### PR TITLE
fix: specify timeZone: GMT for speaking dates

### DIFF
--- a/src/components/speaking/SpeakingEntry.tsx
+++ b/src/components/speaking/SpeakingEntry.tsx
@@ -17,6 +17,7 @@ export function SpeakingEntry(props: SpeakingEntryProps) {
 				props.speaking.data.date.toLocaleString("default", {
 					day: "numeric",
 					month: "short",
+					timeZone: "GMT",
 				}),
 				props.speaking.data.location,
 			]


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #50 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/joshuakgoldberg-dot-com-next/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/joshuakgoldberg-dot-com-next/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Dates are specified in GMT by default, but my local builds are often EST or other.