### PR TITLE
fix: touch up RSS links

### DIFF
--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -8,11 +8,16 @@ export async function get(context: APIContext) {
 		customData: `<language>en-us</language>`,
 		description: blogDescription,
 		site: context.site?.toString() ?? site,
-		items: await pagesGlobToRssItems(
-			// TODO: find or file an issue?
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call
-			import.meta.glob("../content/blog/**/*.mdx")
-		),
+		items: (
+			await pagesGlobToRssItems(
+				// TODO: find or file an issue?
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call
+				import.meta.glob("../content/blog/**/*.mdx")
+			)
+		).map((inner) => ({
+			...inner,
+			link: inner.link.replace(/^src\/content/, "").replace(/index.mdx$/, ""),
+		})),
 		title: "Goldblog",
 	});
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #53 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/joshuakgoldberg-dot-com-next/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/joshuakgoldberg-dot-com-next/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

It was more than just removing `.mdx` from the end. `src/content/` was getting prefixed at the beginning.

I also wanted to remove the trailing slash but it looks like Astro is adding that automatically. 😡 