### PR TITLE
fix: correct description, image, and title around blog posts

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -7,11 +7,7 @@ interface Props {
 	title: string | undefined;
 }
 
-const {
-	description,
-	image: imageRaw,
-	title,
-} = Astro.props;
+const { description, image: imageRaw, title } = Astro.props;
 const image = new URL(imageRaw, Astro.site);
 const keywords = [
 	"accessibility",

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -8,13 +8,11 @@ interface Props {
 }
 
 const {
-	description: descriptionRaw,
+	description,
 	image: imageRaw,
-	title: titleRaw,
+	title,
 } = Astro.props;
-const description = `Hi! I'm Josh. ${descriptionRaw} This is my personal site, built with Astro, Solid, and TypeScript.`;
 const image = new URL(imageRaw, Astro.site);
-const title = titleRaw ? `${titleRaw} | Josh Goldberg` : "Josh Goldberg";
 const keywords = [
 	"accessibility",
 	"developer",

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -9,15 +9,15 @@ import MainArea from "~/components/MainArea.astro";
 export interface Props {
 	class?: string | undefined;
 	description: string;
-	slug: string;
+	image: string;
 	title?: string;
 }
 
-const { class: className, description, slug, title } = Astro.props;
+const { class: className, description, image, title } = Astro.props;
 ---
 
 <html lang="en">
-	<Head description={description} image={`images/${slug}.png`} title={title} />
+	<Head description={description} image={image} title={title} />
 	<div id="#top"></div>
 	<MainArea as="body" class={className}>
 		<Header />

--- a/src/layouts/HeroLayout.astro
+++ b/src/layouts/HeroLayout.astro
@@ -7,18 +7,24 @@ import BaseLayout from "./BaseLayout.astro";
 export interface Props {
 	alt: string;
 	class?: string | undefined;
+	image?: string,
 	primary: string;
 	secondary: string;
 	slug?: string;
 	title?: string;
 }
 
-const { primary, secondary, slug = primary.toLowerCase() } = Astro.props;
+const { primary, secondary, slug = primary.toLowerCase(), title } = Astro.props;
 
 const image = `images/${slug}`;
 ---
 
-<BaseLayout {...Astro.props} description={primary} slug={slug}>
+<BaseLayout
+	{...Astro.props}
+	description={secondary}
+	image={`${image}.png`}
+	title={title ? `${title} | Josh Goldberg` : "Josh Goldberg"}
+>
 	<Hero
 		image={{
 			alt: Astro.props.alt,

--- a/src/layouts/HeroLayout.astro
+++ b/src/layouts/HeroLayout.astro
@@ -7,7 +7,7 @@ import BaseLayout from "./BaseLayout.astro";
 export interface Props {
 	alt: string;
 	class?: string | undefined;
-	image?: string,
+	image?: string;
 	primary: string;
 	secondary: string;
 	slug?: string;

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -24,13 +24,14 @@ if (!entry) {
 }
 
 const rendered = await entry.render();
+const image = entry.data.image?.src
+	? `/images/blog/${entry.data.image.src}`
+	: `/images/goldblog.png`;
 ---
 
 <BaseLayout
 	description={entry.data.description}
-	image={entry.data.image?.src
-		? `/images/blog/${entry.data.image.src}`
-		: `/images/goldblog.png`}
+	image={image}
 	title={`${entry.data.title} | Goldblog`}
 >
 	<BodyContents class="top">

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -28,8 +28,8 @@ const rendered = await entry.render();
 
 <BaseLayout
 	description={entry.data.description}
-	slug={entry.slug}
-	title={entry.data.title}
+	image={entry.data.image?.src ? `/images/blog/${entry.data.image.src}` : `/images/goldblog.png`}
+	title={`${entry.data.title} | Goldblog`}
 >
 	<BodyContents class="top">
 		<BlogHero

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -28,7 +28,9 @@ const rendered = await entry.render();
 
 <BaseLayout
 	description={entry.data.description}
-	image={entry.data.image?.src ? `/images/blog/${entry.data.image.src}` : `/images/goldblog.png`}
+	image={entry.data.image?.src
+		? `/images/blog/${entry.data.image.src}`
+		: `/images/goldblog.png`}
 	title={`${entry.data.title} | Goldblog`}
 >
 	<BodyContents class="top">


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #55
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/joshuakgoldberg-dot-com-next/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/joshuakgoldberg-dot-com-next/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Simplifies some of the piping around metadata now that `BaseLayout` is only ever rendered in blog posts or in `HeroLayout`.