### PR TITLE
fix: correct relative blog post paths

### DIFF
--- a/src/content/blog/how-i-apply-to-conferences-faqs/index.mdx
+++ b/src/content/blog/how-i-apply-to-conferences-faqs/index.mdx
@@ -77,7 +77,7 @@ But do know FAQs such as how it works with data fetching, CSS-in-JS, and other i
 If you're unsure, just submit.
 You never know what the conference organizers will want to branch out to.
 
-Nobody will be irritated or offended by your submission (as long as you do the due diligence mentioned in [How I Apply to Conferences](./how-i-apply-to-conferences)).
+Nobody will be irritated or offended by your submission (as long as you do the due diligence mentioned in [How I Apply to Conferences](/blog/how-i-apply-to-conferences)).
 
 Remember: not all talks have to be technical.
 I've seen fantastic talks at frontend conferences from junior and not-frontend developers on topics such as mentorship and teamwork.

--- a/src/content/blog/speeding-up-centered-part-1-81-iframe-embeds/index.mdx
+++ b/src/content/blog/speeding-up-centered-part-1-81-iframe-embeds/index.mdx
@@ -43,9 +43,9 @@ The net results were quite pleasing:
 This post covers the first of five key improvements I made to the Centered app:
 
 1. 👉 81 &lt;iframe&gt; Embeds
-1. [Hidden Embedded Images](./speeding-up-centered-part-2-hidden-embedded-images)
-1. [Barrel Exports](./speeding-up-centered-part-3-barrel-exports)
-1. [Unused Code Bloat](./speeding-up-centered-part-4-unused-code-bloat)
+1. [Hidden Embedded Images](/blog/speeding-up-centered-part-2-hidden-embedded-images)
+1. [Barrel Exports](/blog/speeding-up-centered-part-3-barrel-exports)
+1. [Unused Code Bloat](/blog/speeding-up-centered-part-4-unused-code-bloat)
 1. _Emoji Processing Time: coming soon!_
 
 Let's dig in!
@@ -217,11 +217,11 @@ Many thanks to:
 ### Up Next
 
 Later posts in this series dive deeper into using dev tools and more intricate code strategies to detect and fix deeper issues.
-Continue reading on the second post, [Speeding Up Centered Part 2: Hidden Embedded Images](./speeding-up-centered-part-2-hidden-embedded-images)!
+Continue reading on the second post, [Speeding Up Centered Part 2: Hidden Embedded Images](/blog/speeding-up-centered-part-2-hidden-embedded-images)!
 ✨
 
 1. 👉 81 &lt;iframe&gt; Embeds
-1. [Hidden Embedded Images](./speeding-up-centered-part-2-hidden-embedded-images)
-1. [Barrel Exports](./speeding-up-centered-part-3-barrel-exports)
-1. [Unused Code Bloat](./speeding-up-centered-part-4-unused-code-bloat)
+1. [Hidden Embedded Images](/blog/speeding-up-centered-part-2-hidden-embedded-images)
+1. [Barrel Exports](/blog/speeding-up-centered-part-3-barrel-exports)
+1. [Unused Code Bloat](/blog/speeding-up-centered-part-4-unused-code-bloat)
 1. _Emoji Processing Time: coming soon!_

--- a/src/content/blog/speeding-up-centered-part-2-hidden-embedded-images/index.mdx
+++ b/src/content/blog/speeding-up-centered-part-2-hidden-embedded-images/index.mdx
@@ -16,12 +16,12 @@ import webpackBundleAnalyzerClientBefore from "./webpack-bundle-analyzer-client-
 import webpackBundleAnalyzerClientAfter from "./webpack-bundle-analyzer-client-after.png";
 
 > This post is the second in a series of five performance improvements I made to the [Centered app](https://centered.app).
-> See [81 &lt;iframe&gt; Embeds](./speeding-up-centered-part-1-81-iframe-embeds) for more context.
+> See [81 &lt;iframe&gt; Embeds](/blog/speeding-up-centered-part-1-81-iframe-embeds) for more context.
 
-1. [81 &lt;iframe&gt; Embeds](./speeding-up-centered-part-1-81-iframe-embeds)
+1. [81 &lt;iframe&gt; Embeds](/blog/speeding-up-centered-part-1-81-iframe-embeds)
 1. 👉 Hidden Embedded Images
-1. [Barrel Exports](./speeding-up-centered-part-3-barrel-exports)
-1. [Unused Code Bloat](./speeding-up-centered-part-4-unused-code-bloat)
+1. [Barrel Exports](/blog/speeding-up-centered-part-3-barrel-exports)
+1. [Unused Code Bloat](/blog/speeding-up-centered-part-4-unused-code-bloat)
 1. _Emoji Processing Time: coming soon!_
 
 ## Issue 2: Hidden Images
@@ -154,13 +154,13 @@ You never know how far any improvement will take the page!
 Deleting the largest offending file wasn't enough to fully save Centered's lighthouse performance score.
 And why was an unused file even being loaded on the client in the first place?!
 
-[Speeding Up Centered Part 3: Barrel Exports](./speeding-up-centered-part-3-barrel-exports) shows off how we removed plenty more unnecessary files to get that performance score out of the red.
+[Speeding Up Centered Part 3: Barrel Exports](/blog/speeding-up-centered-part-3-barrel-exports) shows off how we removed plenty more unnecessary files to get that performance score out of the red.
 It produced much more encouraging performance improvements - would recommend reading on!
 
-1. [81 &lt;iframe&gt; Embeds](./speeding-up-centered-part-1-81-iframe-embeds)
+1. [81 &lt;iframe&gt; Embeds](/blog/speeding-up-centered-part-1-81-iframe-embeds)
 1. 👉 Hidden Embedded Images
-1. [Barrel Exports](./speeding-up-centered-part-3-barrel-exports)
-1. [Unused Code Bloat](./speeding-up-centered-part-4-unused-code-bloat)
+1. [Barrel Exports](/blog/speeding-up-centered-part-3-barrel-exports)
+1. [Unused Code Bloat](/blog/speeding-up-centered-part-4-unused-code-bloat)
 1. _Emoji Processing Time: coming soon!_
 
 [^1]: https://almanac.httparchive.org/en/2022/page-weight#request-bytes

--- a/src/content/blog/speeding-up-centered-part-3-barrel-exports/index.mdx
+++ b/src/content/blog/speeding-up-centered-part-3-barrel-exports/index.mdx
@@ -15,17 +15,17 @@ import webpackBundleAnalyzerAfterCodemod from "./webpack-bundle-analyzer-after-c
 import webpackBundleAnalyzerAfterProLight from "./webpack-bundle-analyzer-after-pro-light.png";
 
 > This post is the third in a series of five performance improvements I made to the [Centered app](https://centered.app).
-> See [81 &lt;iframe&gt; Embeds](./speeding-up-centered-part-1-81-iframe-embeds) for more context.
+> See [81 &lt;iframe&gt; Embeds](/blog/speeding-up-centered-part-1-81-iframe-embeds) for more context.
 
-1. [81 &lt;iframe&gt; Embeds](./speeding-up-centered-part-1-81-iframe-embeds)
-1. [Hidden Embedded Images](./speeding-up-centered-part-2-hidden-embedded-images)
+1. [81 &lt;iframe&gt; Embeds](/blog/speeding-up-centered-part-1-81-iframe-embeds)
+1. [Hidden Embedded Images](/blog/speeding-up-centered-part-2-hidden-embedded-images)
 1. 👉 Barrel Exports
-1. [Unused Code Bloat](./speeding-up-centered-part-4-unused-code-bloat)
+1. [Unused Code Bloat](/blog/speeding-up-centered-part-4-unused-code-bloat)
 1. _Emoji Processing Time: coming soon!_
 
 ## Issue 3: Barrel Exports
 
-In the previous Centered performance post, [Hidden Embedded Images](./speeding-up-centered-part-2-hidden-embedded-images), we saw one gigantic React component increase the client bundle size by multiple MB.
+In the previous Centered performance post, [Hidden Embedded Images](/blog/speeding-up-centered-part-2-hidden-embedded-images), we saw one gigantic React component increase the client bundle size by multiple MB.
 But that component wasn't even used by any runtime - why was it impacting performance?
 And if this "unused" file was previously getting loaded, how many other unused node files were also being loaded?
 
@@ -204,10 +204,10 @@ At time of investigation, Centered was still on 13.0.
 This work area brought the Lighthouse Performance score up to orange instead of red, but there was still more work to be done.
 The next two investigations will show a couple more touchups I applied to remove unused code and script work.
 
-1. [81 &lt;iframe&gt; Embeds](./speeding-up-centered-part-1-81-iframe-embeds)
-1. [Hidden Embedded Images](./speeding-up-centered-part-2-hidden-embedded-images)
+1. [81 &lt;iframe&gt; Embeds](/blog/speeding-up-centered-part-1-81-iframe-embeds)
+1. [Hidden Embedded Images](/blog/speeding-up-centered-part-2-hidden-embedded-images)
 1. 👉 Barrel Exports
-1. [Unused Code Bloat](./speeding-up-centered-part-4-unused-code-bloat)
+1. [Unused Code Bloat](/blog/speeding-up-centered-part-4-unused-code-bloat)
 1. _Emoji Processing Time: coming soon!_
 
 [^1]: https://basarat.gitbook.io/typescript/main-1/barrel

--- a/src/content/blog/speeding-up-centered-part-4-unused-code-bloat/index.mdx
+++ b/src/content/blog/speeding-up-centered-part-4-unused-code-bloat/index.mdx
@@ -11,18 +11,18 @@ import LabeledImage from "~/components/blog/mdx/LabeledImage.astro";
 import LabeledVideo from "~/components/blog/mdx/LabeledVideo.astro";
 
 > This post is the fourth in a series of five performance improvements I made to the [Centered app](https://centered.app).
-> See [81 &lt;iframe&gt; Embeds](./speeding-up-centered-part-1-81-iframe-embeds) for more context.
+> See [81 &lt;iframe&gt; Embeds](/blog/speeding-up-centered-part-1-81-iframe-embeds) for more context.
 
-1. [81 &lt;iframe&gt; Embeds](./speeding-up-centered-part-1-81-iframe-embeds)
-1. [Hidden Embedded Images](./speeding-up-centered-part-2-hidden-embedded-images)
-1. [Barrel Exports](./speeding-up-centered-part-3-barrel-exports)
+1. [81 &lt;iframe&gt; Embeds](/blog/speeding-up-centered-part-1-81-iframe-embeds)
+1. [Hidden Embedded Images](/blog/speeding-up-centered-part-2-hidden-embedded-images)
+1. [Barrel Exports](/blog/speeding-up-centered-part-3-barrel-exports)
 1. 👉 _Unused Code Bloat_
 1. _Emoji Processing Time: coming soon!_
 
 ## Issue 4: Unused Code Bloat
 
-The changes I'd made in the Centered performance post, [Barrel Exports](./speeding-up-centered-part-3-barrel-exports), improved Centered's tree shaking to defer loading portions of larger shared packages.
-But in the previous performance post, [Hidden Embedded Images](./speeding-up-centered-part-2-hidden-embedded-images), we'd seen how a single unused file significantly increased bundle size despite not being referenced anywhere.
+The changes I'd made in the Centered performance post, [Barrel Exports](/blog/speeding-up-centered-part-3-barrel-exports), improved Centered's tree shaking to defer loading portions of larger shared packages.
+But in the previous performance post, [Hidden Embedded Images](/blog/speeding-up-centered-part-2-hidden-embedded-images), we'd seen how a single unused file significantly increased bundle size despite not being referenced anywhere.
 I had to wonder whether there were other unused files, and if so, whether they were contributing to load time.
 Even if their load was deferred, surely removing them would have some positive impact on page performance, right?
 
@@ -120,8 +120,8 @@ The next post in this series will be the final one, but I've been saving the bes
 It'll show how I discovered runtime code in a package wasting _multiple seconds_ on repeated work (!).
 Look forward to it later this month!
 
-1. [81 &lt;iframe&gt; Embeds](./speeding-up-centered-part-1-81-iframe-embeds)
-1. [Hidden Embedded Images](./speeding-up-centered-part-2-hidden-embedded-images)
-1. [Barrel Exports](./speeding-up-centered-part-3-barrel-exports)
+1. [81 &lt;iframe&gt; Embeds](/blog/speeding-up-centered-part-1-81-iframe-embeds)
+1. [Hidden Embedded Images](/blog/speeding-up-centered-part-2-hidden-embedded-images)
+1. [Barrel Exports](/blog/speeding-up-centered-part-3-barrel-exports)
 1. 👉 _Unused Code Bloat_
 1. _Emoji Processing Time: coming soon!_

--- a/src/content/blog/typescript-contribution-diary-errors-for-identifiers-after-numeric-literals/index.mdx
+++ b/src/content/blog/typescript-contribution-diary-errors-for-identifiers-after-numeric-literals/index.mdx
@@ -17,7 +17,7 @@ import tsdevtestVariousErrors from "./tsdevtest-various-errors.webp";
 > These blog posts are documentation of the steps I took to figure out what to do for these contributes & then do them.
 > If you're thinking of contributing to TypeScript or other large open source libraries, I hope seeing how to delve into a giant foreign monolith is of some help!
 
-> Previous post: [Pretty Error Counts](./typescript-contribution-diary-pretty-error-counts)
+> Previous post: [Pretty Error Counts](/blog/typescript-contribution-diary-pretty-error-counts)
 
 <LabeledImage
 	alt="Meme of drake gesturing away from a first panel and happily pointing towards a second. First: 'User reported bugs or feature suggestions'. Second: 'ECMAScript spec syntax errata'."
@@ -234,7 +234,7 @@ The error showed!
 
 ## Test Time
 
-Per my previous post on [verifying parser changes](./typescript-contribution-diary-trailing-type-parameter), TypeScript has a "baselines" system where you check in source files with expected types and errors.
+Per my previous post on [verifying parser changes](/blog/typescript-contribution-diary-trailing-type-parameter), TypeScript has a "baselines" system where you check in source files with expected types and errors.
 I added a `tests/cases/compiler/identifierStartAfterNumericLiteral.ts` to explicitly test these changes:
 
 ```ts

--- a/src/content/blog/typescript-contribution-diary-pretty-error-counts/index.mdx
+++ b/src/content/blog/typescript-contribution-diary-pretty-error-counts/index.mdx
@@ -30,9 +30,9 @@ import tscPrettyWatchBlueMessage from "./tsc-pretty-watch-blue-message.webp";
 > These blog posts are documentation of the steps I took to figure out what to do for these contributes & then do them.
 > If you're thinking of contributing to TypeScript or other large open source libraries, I hope seeing how to delve into a giant foreign monolith is of some help!
 
-> Previous post: [Trailing Type Parameters](./typescript-contribution-diary-trailing-type-parameters)
+> Previous post: [Trailing Type Parameters](/blog/typescript-contribution-diary-trailing-type-parameters)
 
-> Next post: [Identifiers after Numeric Literals](./typescript-contribution-diary-identifiers-after-numeric-literals)
+> Next post: [Identifiers after Numeric Literals](/blog/typescript-contribution-diary-identifiers-after-numeric-literals)
 
 ## Problem Statement
 

--- a/src/content/blog/typescript-contribution-diary-trailing-type-parameters/index.mdx
+++ b/src/content/blog/typescript-contribution-diary-trailing-type-parameters/index.mdx
@@ -14,7 +14,7 @@ import chromeTrailer from "./chrome-trailer.webp";
 > These blog posts are documentation of the steps I took to figure out what to do for these contributes & then do them.
 > If you're thinking of contributing to TypeScript or other large open source libraries, I hope seeing how to delve into a giant foreign monolith is of some help!
 
-> Next post: [Pretty Error Counts](./typescript-contribution-diary-pretty-error-counts)
+> Next post: [Pretty Error Counts](/blog/typescript-contribution-diary-pretty-error-counts)
 
 <LabeledImage
 	alt="Parked shiny chrome trailer outside with trees and a hill in the background."


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #70
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/joshuakgoldberg-dot-com-next/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/joshuakgoldberg-dot-com-next/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Makes it so all mdx anchors start from `/blog/`.