### PR TITLE
feat: more line-height for dark mode

### DIFF
--- a/src/components/blog/BlogContent.module.css
+++ b/src/components/blog/BlogContent.module.css
@@ -4,7 +4,8 @@
 	font-size: var(--fontSizeSmall);
 	gap: 1rem;
 	font-weight: 300;
-	line-height: 1.35;
+	line-height: var(--lineHeightParagraph);
+	transition: line-height var(--transitionSlow);
 }
 
 .article a {

--- a/src/layouts/base.css
+++ b/src/layouts/base.css
@@ -20,6 +20,9 @@
 		--fontWeightBold: 600;
 		--fontWeightBolder: 700;
 
+		--lineHeightBase: 1.1;
+		--lineHeightParagraph: 1.35;
+
 		--textShadow: 3px 3px 1px var(--colorSubtle);
 
 		--transitionMedium: 280ms;
@@ -67,7 +70,7 @@
 				)
 				no-repeat;
 		overflow-y: auto;
-		line-height: 1.1;
+		line-height: var(--lineHeightBase);
 		position: fixed;
 		top: 0;
 		bottom: 0;
@@ -99,6 +102,8 @@
 			--colorForeground: #dae7f3;
 			--colorForegroundExtra: #e5edf3;
 			--colorSubtle: #052438;
+
+			--lineHeightParagraph: 1.5;
 
 			/* Note: some of these are unused in Prism, but would be in Shiki. */
 			--astro-code-color-text: #d3d6f0;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #120
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/joshuakgoldberg-dot-com-next/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/joshuakgoldberg-dot-com-next/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds CSS variables for the two common line heights. With a cute little transition in blog posts too!