### PR TITLE
fix(header ui): removed squiggly render on keyboard focus in header links

### DIFF
--- a/src/components/Squiggly.module.css
+++ b/src/components/Squiggly.module.css
@@ -33,6 +33,8 @@
 	transform: scale(1 1.17);
 }
 
-.squiggly:is(.alwaysActive, .passive, :hover):not(.inactive)::after {
+.squiggly:is(.alwaysActive, .passive, :focus-visible, :hover):not(
+		.inactive
+	)::after {
 	opacity: 1;
 }

--- a/src/components/Squiggly.module.css
+++ b/src/components/Squiggly.module.css
@@ -33,6 +33,6 @@
 	transform: scale(1 1.17);
 }
 
-.squiggly:is(.alwaysActive, .passive, :focus, :hover):not(.inactive)::after {
+.squiggly:is(.alwaysActive, .passive, :hover):not(.inactive)::after {
 	opacity: 1;
 }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to joshuakgoldberg-dot-com-next! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #156
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/joshuakgoldberg-dot-com-next/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/joshuakgoldberg-dot-com-next/blob/main/.github/CONTRIBUTING.md) were taken

## Overview
The `Squiggly` component was rendering a squiggly line on links in the header on keyboard focus, which led the side effect where external navigation to the Books link would render the squiggly line upon returning to the site, even though the native browser focus box is not active on that Books text.

The screenshot illustrates the side effect that was fixed. This behavior was triggered after navigating to the Books link and then returning back to the site.

Before:
![booksbefore](https://github.com/JoshuaKGoldberg/dot-com/assets/2034081/bbc4f165-14d1-4976-a06d-b8c4b6f84231)

After:
![booksafter](https://github.com/JoshuaKGoldberg/dot-com/assets/2034081/65971acb-3ee8-4073-8195-b3ce7441d538)


<!-- Description of what is changed and how the code change does that. -->
