### PR TITLE
fix: move video styles to LabeledMedia.astro

### DIFF
--- a/src/components/blog/mdx/LabeledMedia.astro
+++ b/src/components/blog/mdx/LabeledMedia.astro
@@ -45,6 +45,7 @@ const descriptions =
 		display: block;
 		margin-top: 1rem;
 	}
+
 	.labeled-media-note {
 		font-size: 0.9em;
 		padding-bottom: 1rem;
@@ -57,5 +58,14 @@ const descriptions =
 
 	.labeled-media-original::before {
 		content: "[";
+	}
+
+	/* Ideally these would be in a LoopVideo.module.css... */
+	/* https://github.com/JoshuaKGoldberg/dot-com/issues/190 */
+	.labeled-media-media video {
+		margin: auto;
+		max-height: fit-content;
+		max-width: fit-content;
+		width: 100%;
 	}
 </style>

--- a/src/components/blog/mdx/LoopedVideo.module.css
+++ b/src/components/blog/mdx/LoopedVideo.module.css
@@ -1,6 +1,0 @@
-.loopedVideo {
-	margin: auto;
-	max-height: fit-content;
-	max-width: fit-content;
-	width: 100%;
-}

--- a/src/components/blog/mdx/LoopedVideo.tsx
+++ b/src/components/blog/mdx/LoopedVideo.tsx
@@ -1,5 +1,3 @@
-import styles from "./LoopedVideo.module.css";
-
 export interface LoopedVideoProps {
 	src: string;
 	title: string;
@@ -9,7 +7,6 @@ export function LoopedVideo(props: LoopedVideoProps) {
 	return (
 		<video
 			autoplay
-			class={styles.loopedVideo}
 			muted
 			ref={(element) => {
 				const media = window.matchMedia("(prefers-reduced-motion: reduce)");


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #190
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/dot-com/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/dot-com/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Works around an apparent _(to me)_ Astro bug _(or misinterpretation of how Astro works)_ by moving `LoopedVideo`'s styles up to `LabeledMedia.astro`. Right now they're not loading on prod.