### PR TITLE
fix: switch pie chart legend and title to HTML/CSS

### DIFF
--- a/src/components/PieChart.module.css
+++ b/src/components/PieChart.module.css
@@ -1,0 +1,34 @@
+.figure {
+	align-items: center;
+	display: flex;
+	flex-direction: column;
+	margin: 0;
+}
+
+.figure > * {
+	max-height: 25rem;
+}
+
+.title {
+	text-align: center;
+}
+
+.captions {
+	justify-content: center;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem 1rem;
+	margin: 0.75rem 0;
+}
+
+.caption {
+	align-items: baseline;
+	display: inline-flex;
+	gap: 0.35rem;
+}
+
+.colorBlock {
+	display: inline-block;
+	width: 1.5rem;
+	height: 0.7rem;
+}

--- a/src/components/PieChart.tsx
+++ b/src/components/PieChart.tsx
@@ -3,12 +3,13 @@ import {
 	ArcElement,
 	Chart,
 	Colors,
-	Legend,
-	Title,
 	Tooltip,
 } from "chart.js";
 import { type ChartProps, Pie } from "solid-chartjs";
-import { onMount } from "solid-js";
+import { For, onMount } from "solid-js";
+
+import styles from "./PieChart.module.css";
+import { Text } from "./Text";
 
 export interface PieChartProps {
 	colors: string[];
@@ -25,33 +26,33 @@ export interface PieChartProps {
 	title: string;
 }
 
-const fontBase = {
-	family: "League SpartanVariable",
-};
-
 export function PieChart(props: PieChartProps) {
 	/**
 	 * You must register optional elements before using the chart,
 	 * otherwise you will have the most primitive UI
 	 */
 	onMount(() => {
-		Chart.register(ArcElement, Colors, Legend, Title, Tooltip);
+		Chart.register(ArcElement, Colors, Tooltip);
 	});
 
 	return (
-		<div
-			aria-label={[
-				"Pie chart: ",
-				props.title,
-				". ",
-				props.data.datasets[0].label,
-				": ",
-				props.data.datasets[0].data
-					.map((value, i) => `${props.data.labels[i]}, ${value}`)
-					.join("; "),
-				".",
-			].join("")}
-		>
+		<figure class={styles.figure}>
+			<h4 class={styles.title}>{props.title}</h4>
+			<figcaption class={styles.captions}>
+				<For each={props.data.datasets[0].data.map((data, i) => [data, i])}>
+					{([value, i]) => (
+						<Text as="div" class={styles.caption} fontSize="smaller">
+							<span
+								class={styles.colorBlock}
+								style={{ "background-color": props.colors[i] }}
+							/>
+							<span>
+								{props.data.labels[i]}: ${value}
+							</span>
+						</Text>
+					)}
+				</For>
+			</figcaption>
 			<Pie
 				data={props.data}
 				options={{
@@ -66,30 +67,10 @@ export function PieChart(props: PieChartProps) {
 							bottom: 20,
 						},
 					},
-					maintainAspectRatio: false,
-					plugins: {
-						legend: {
-							labels: {
-								font: {
-									...fontBase,
-									size: 16,
-								},
-							},
-						},
-						title: {
-							display: true,
-							font: {
-								...fontBase,
-								size: 20,
-							},
-							fullSize: true,
-							padding: 20,
-							text: props.title,
-						},
-					},
+					maintainAspectRatio: true,
 					responsive: true,
 				}}
 			/>
-		</div>
+		</figure>
 	);
 }

--- a/src/components/PieChart.tsx
+++ b/src/components/PieChart.tsx
@@ -27,10 +27,6 @@ export interface PieChartProps {
 }
 
 export function PieChart(props: PieChartProps) {
-	/**
-	 * You must register optional elements before using the chart,
-	 * otherwise you will have the most primitive UI
-	 */
 	onMount(() => {
 		Chart.register(ArcElement, Colors, Tooltip);
 	});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #189
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/dot-com/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/dot-com/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Switches to using manual HTML for the legend and title, so that I can have it all inherit CSS styles.