### PR TITLE
feat: lazy-load images

### DIFF
--- a/src/components/HeroImage.tsx
+++ b/src/components/HeroImage.tsx
@@ -60,6 +60,7 @@ export function HeroImage(props: HeroImageProps) {
 				<img
 					alt={props.alt}
 					class={props.size}
+					loading="lazy"
 					onLoad={markLoaded}
 					ref={(element) => {
 						if (element.complete) {

--- a/src/components/entries/ContentEntryImage.tsx
+++ b/src/components/entries/ContentEntryImage.tsx
@@ -33,6 +33,7 @@ export function ContentEntryImage(props: ContentEntryImageProps) {
 				variants[props.variant],
 				loaded() && styles.contentEntryImageLoaded,
 			)}
+			loading="lazy"
 			onLoad={markLoaded}
 			ref={(element) => {
 				if (element.complete) {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #199
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/dot-com/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/dot-com/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses the `lazy` attribute as described in the issue.

The nice thing is, since fade-ins are triggered on image load, scrolling down the page lets you see images fade in in-real-time on first visit. Nifty!