### PR TITLE
fix: respect project owner in GitHub URLs

### DIFF
--- a/src/components/projects/ProjectEntry.tsx
+++ b/src/components/projects/ProjectEntry.tsx
@@ -10,8 +10,8 @@ export interface ProjectEntryProps {
 	project: Project;
 }
 
-function projectUrl(project: ProjectBase) {
-	return project.url ?? `https://github.com/JoshuaKGoldberg/${project.repo}`;
+function projectUrl({ owner = "JoshuaKGoldberg", repo, url }: ProjectBase) {
+	return url ?? `https://github.com/${owner}/${repo}`;
 }
 
 function projectTitle(project: ProjectBase) {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #212
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/dot-com/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/dot-com/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Defaults the `owner` to `"JoshuaKGoldberg"`.