### PR TITLE
fix: small page width overflows

### DIFF
--- a/src/components/BodyContents.astro
+++ b/src/components/BodyContents.astro
@@ -13,7 +13,7 @@ const { as: As = "div", ...rest } = Astro.props;
 
 <style>
 	.bodyContents {
-		padding: 0 2rem;
+		padding: 0 var(--widthPagePadding);
 	}
 
 	@media (min-width: 1017px) {

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -22,7 +22,7 @@ import { Text } from "./Text";
 <style>
 	footer {
 		opacity: 0.75;
-		padding: clamp(2.8rem, 5vmin, 7rem) 2rem 3rem;
+		padding: clamp(2.8rem, 5vmin, 7rem) var(--widthPagePadding) 3rem;
 		justify-self: flex-end;
 	}
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -32,7 +32,7 @@ const links = [
 		flex-wrap: wrap;
 		gap: 0.5rem 3.5rem;
 		justify-content: space-between;
-		padding: 2rem;
+		padding: 2rem var(--widthPagePadding);
 		position: relative;
 		width: 100%;
 	}

--- a/src/components/blog/BlogHero.astro
+++ b/src/components/blog/BlogHero.astro
@@ -20,15 +20,6 @@ interface Props {
 <div class:list={["blogHero", Astro.props.class]}>
 	<div class="left">
 		<div class="primary">
-			<div class="hero-title">
-				<HeroTitle>
-					{
-						Astro.props.title
-							// TODO: use a markdown renderer
-							.replaceAll("`", "")
-					}
-				</HeroTitle>
-			</div>
 			{
 				Astro.props.image && (
 					<div class="hero-image">
@@ -41,6 +32,15 @@ interface Props {
 					</div>
 				)
 			}
+			<div class="hero-title">
+				<HeroTitle>
+					{
+						Astro.props.title
+							// TODO: use a markdown renderer
+							.replaceAll("`", "")
+					}
+				</HeroTitle>
+			</div>
 			<div class="hero-tertiary">
 				<HeroTertiary>
 					<DateAndMinutes
@@ -79,30 +79,12 @@ interface Props {
 
 <style>
 	.primary {
-		--imageSize: var(--heroSizeSmall);
-
-		display: grid;
-		column-gap: 0.5rem;
-		grid-template-columns: auto var(--imageSize);
-		grid-template-rows: max-content max-content auto;
 		width: 100%;
 	}
 
 	.hero-image {
-		grid-column: 2;
-		grid-row: 1 / 3;
-		display: flex;
-		justify-content: flex-end;
-	}
-
-	.hero-title {
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
-	}
-
-	.hero-tertiary {
-		grid-column: 1 / 3;
+		float: right;
+		margin-left: 0.1rem;
 	}
 
 	.download {
@@ -110,7 +92,31 @@ interface Props {
 	}
 
 	@media (min-width: 490px) {
+		.primary {
+			--imageSize: var(--heroSizeSmall);
+
+			display: grid;
+			column-gap: 0.5rem;
+			grid-template-columns: auto var(--imageSize);
+			grid-template-rows: max-content max-content auto;
+		}
+
+		.hero-image {
+			grid-column: 2;
+			grid-row: 1 / 3;
+			display: flex;
+			justify-content: flex-end;
+			margin-left: 0;
+		}
+
+		.hero-title {
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+		}
+
 		.hero-tertiary {
+			grid-column: 1 / 3;
 			grid-row: 2;
 		}
 	}

--- a/src/layouts/base.css
+++ b/src/layouts/base.css
@@ -33,12 +33,13 @@
 
 		--heightMinimumFromHeader: clamp(7rem, 15vmin, 9rem);
 
-		--heroSizeSmall: clamp(5rem, 12vmin, 9rem);
+		--heroSizeSmall: clamp(6rem, 12vmin, 9rem);
 		--heroSizeLarge: clamp(6rem, 20vmin, 12rem);
 
 		--widthFull: 63rem;
 		--widthSlim: 47rem;
 		--widthTableOfContents: 15rem;
+		--widthPagePadding: clamp(0.5rem, 5vw, 2rem);
 
 		/* Note: some of these are unused in Prism, but would be in Shiki. */
 		--astro-code-color-background: transparent;
@@ -146,5 +147,6 @@
 @media (min-width: 1017px) {
 	:root {
 		--heroSizeLarge: 256px;
+		--widthPagePadding: 0;
 	}
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #253
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/dot-com/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/dot-com/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Makes two small adjustments so that blog posts don't stretch small viewports horizontally:

* Standardizes page width padding to be clamped, with a `1rem` minimum instead of the previous consistent `2rem` 
* Floats the hero image at <490px resolutions, instead of the column-based grid layout


<img width="424" alt="image" src="https://github.com/JoshuaKGoldberg/dot-com/assets/3335181/109bf18e-51ec-467a-acfd-9967791450f9">
