### PR TITLE
fix: normalized left padding for Heros

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -25,7 +25,7 @@ interface Props {
 <style>
 	.hero {
 		margin: clamp(2rem, 8vmin, 8rem) auto;
-		padding: 0 2rem 1rem;
+		padding: 0 var(--widthPagePadding) 1rem;
 		position: relative;
 		width: var(--widthFull);
 		max-width: 100%;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #264
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/dot-com/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/dot-com/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses the `var(--widthPagePadding)` introduced in #254.