### PR TITLE
fix: typo about ESLint as a default formatter

### DIFF
--- a/src/content/blog/configuring-eslint-prettier-and-typescript-together/index.mdx
+++ b/src/content/blog/configuring-eslint-prettier-and-typescript-together/index.mdx
@@ -352,7 +352,7 @@ I'd also encourage you to enable the [ESLint extension for VS Code](https://mark
 }
 ```
 
-...then set it as your default formatter and enable linting on save in your [`.vscode/settings.json` workspace settings](https://code.visualstudio.com/docs/getstarted/settings#_workspace-settings):
+...then enable linting on save in your [`.vscode/settings.json` workspace settings](https://code.visualstudio.com/docs/getstarted/settings#_workspace-settings):
 
 ```json
 // .vscode/settings.json​


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #282
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/dot-com/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/dot-com/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Removes the erroneous mention of ESLint as a formatter.

💖 