### PR TITLE
fix: correct style for squiggly URL

### DIFF
--- a/src/components/Squiggly.tsx
+++ b/src/components/Squiggly.tsx
@@ -43,7 +43,7 @@ export function Squiggly<As extends keyof JSX.HTMLElementTags>(
 				props.class,
 			)}
 			fontSize={squigglyProps.fontSize}
-			style={`--squiggle: url('${squiggle.src})`}
+			style={`--squiggle: url('${squiggle.src}')`}
 		>
 			{props.children}
 		</Text>


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #330
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/dot-com/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/dot-com/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I'd missed an apostrophe in the inline `style` declaration. The local dev mode tolerated it, but production builds didn't. Nifty!

💖 