### PR TITLE
fix: change broken URL to Jan's post

### DIFF
--- a/src/content/blog/how-i-apply-to-conferences/index.mdx
+++ b/src/content/blog/how-i-apply-to-conferences/index.mdx
@@ -216,7 +216,7 @@ See my [How I Apply to Conferences: FAQs](../how-i-apply-to-conferences-faqs) ar
 On top of the references mentioned in this article, I recommend reading at least these two articles:
 
 - [How to write an effective conference talk abstract](https://dev.to/benghamine/on-conference-speaking-and-effective-talk-abstracts-2bp6): A fantastic deep dive on good and bad abstracts in CFPs.
-- [How To Give the Killer Tech Talk — A Pamphlet](https://writing.jan.io/2013/05/10/how-to-give-the-killer-tech-talk---a-pamphlet.html): Great, actionable tips on giving the talk.
+- [How To Give the Killer Tech Talk — A Pamphlet](https://writing.jan.io/2013/05/10/how-to-give-the-killer-tech-talk-a-pamphlet.html): Great, actionable tips on giving the talk.
 
 Edit 11/18: [Luis Sánchez](https://twitter.com/chiefblagger), an organizer of conferences including [J on the Beach](https://www.jonthebeach.com) and [Wey Wey Web](https://weyweyweb.com), wrote a great post from an organizer's point of view: [CFP Tips and Tricks for Tech Conferences](https://www.jonthebeach.com/blog/CFP-Tips-and-Tricks-for-Tech-Conferences).
 Would recommend!


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/dot-com/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/dot-com/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The URL to [How To Give the Killer Tech Talk](https://writing.jan.io/2013/05/10/how-to-give-the-killer-tech-talk-a-pamphlet.html) had some extra dashes, resulting in a 404. This commit corrects that.

There are no open issues for this, but I believe the fix is small enough. After all, it exactly matches the example edge case from CONTRIBUTING.md :) 
